### PR TITLE
feat: secure config and gateway-first routing for Notion comment plugin

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,10 +1,14 @@
 {
-    "notionApiKey": "secret_your_notion_integration_token",
-    "pollIntervalMinutes": 15,
-    "indexPage": "",
-    "watchedPages": [],
-    "integrationUserId": "",
-    "aiBaseUrl": "https://right.codes/codex/v1",
-    "aiApiKey": "your-ai-api-key",
-    "aiModel": "gpt-5.3-codex-xhigh"
+  "notionApiKeyEnv": "NOTION_API_KEY",
+  "pollIntervalMinutes": 15,
+  "indexPage": "",
+  "watchedPages": [],
+  "integrationUserId": "",
+  "useGatewayChatCompletions": true,
+  "gatewayBaseUrl": "http://127.0.0.1:18789/v1",
+  "gatewayApiKeyEnv": "OPENCLAW_GATEWAY_TOKEN",
+  "aiBaseUrl": "https://right.codes/codex/v1",
+  "aiApiKeyEnv": "RIGHTCODE_API_KEY",
+  "aiModel": "openclaw:friday",
+  "systemPrompt": "你是一个友好、专业的 AI 助手。用户在 Notion 文档中发表了评论，请用简洁的中文回复。不要使用 Markdown 格式。"
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,32 +1,96 @@
 {
-    "id": "notion-doc-comment",
-    "name": "Notion Document Comment",
-    "version": "0.1.0",
-    "description": "Monitor and respond to Notion page comments via polling. Supports index page pattern.",
-    "author": "Clark",
-    "configSchema": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-            "enabled": {
-                "type": "boolean",
-                "default": true
-            },
-            "pollIntervalMinutes": {
-                "type": "number",
-                "default": 15
-            },
-            "indexPage": {
-                "type": "string",
-                "description": "ID of index page containing links to monitored pages"
-            },
-            "watchedPages": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                },
-                "default": []
-            }
-        }
+  "id": "notion-doc-comment",
+  "name": "Notion Document Comment",
+  "version": "0.2.0",
+  "description": "Monitor and respond to Notion page comments via polling. Supports index page pattern.",
+  "author": "Clark",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "default": true
+      },
+      "pollIntervalMinutes": {
+        "type": "number",
+        "minimum": 1,
+        "default": 15
+      },
+      "indexPage": {
+        "type": "string",
+        "description": "ID of index page containing links to monitored pages"
+      },
+      "watchedPages": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": []
+      },
+      "notionApiKey": {
+        "type": "string",
+        "description": "Notion integration secret (prefer notionApiKeyEnv in production)"
+      },
+      "notionApiKeyEnv": {
+        "type": "string",
+        "description": "Environment variable name for Notion API key (e.g. NOTION_API_KEY)"
+      },
+      "integrationUserId": {
+        "type": "string",
+        "description": "Notion integration user id to avoid self-reply loops"
+      },
+      "useGatewayChatCompletions": {
+        "type": "boolean",
+        "default": true,
+        "description": "Prefer local OpenClaw gateway /v1/chat/completions over external AI API"
+      },
+      "gatewayBaseUrl": {
+        "type": "string",
+        "default": "http://127.0.0.1:18789/v1"
+      },
+      "gatewayApiKey": {
+        "type": "string",
+        "description": "Optional Bearer token for gateway HTTP endpoint"
+      },
+      "gatewayApiKeyEnv": {
+        "type": "string",
+        "description": "Environment variable name for gateway token"
+      },
+      "aiBaseUrl": {
+        "type": "string",
+        "default": "https://right.codes/codex/v1"
+      },
+      "aiApiKey": {
+        "type": "string",
+        "description": "External AI API key for fallback mode"
+      },
+      "aiApiKeyEnv": {
+        "type": "string",
+        "description": "Environment variable name for external AI API key"
+      },
+      "aiModel": {
+        "type": "string",
+        "default": "openclaw:friday"
+      },
+      "systemPrompt": {
+        "type": "string",
+        "description": "Optional system prompt override"
+      }
     }
+  },
+  "uiHints": {
+    "notionApiKey": {
+      "sensitive": true,
+      "label": "Notion API Key"
+    },
+    "gatewayApiKey": {
+      "sensitive": true,
+      "label": "Gateway API Key"
+    },
+    "aiApiKey": {
+      "sensitive": true,
+      "label": "External AI API Key"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

This PR upgrades `notion-doc-comment` for production safety and better OpenClaw integration:

- add env-based secret support (avoid plain-text keys in config)
- support `plugins.entries.<id>.config` (with legacy `config.json` compatibility)
- prefer local OpenClaw Gateway `/v1/chat/completions` by default
- fallback to external AI API when gateway is unavailable
- update plugin schema/ui hints and README docs

## Why

Current behavior works but has operational risks:

1. secrets are commonly stored in plain `config.json`
2. AI path is external-only, not aligned with OpenClaw routing
3. plugin-level config via `plugins.entries.<id>.config` was not leveraged
4. README clone URL mismatch and limited deployment guidance

## Changes

### 1) `plugin.ts`

- Added config fields:
  - `notionApiKeyEnv`
  - `aiApiKeyEnv`
  - `useGatewayChatCompletions`
  - `gatewayBaseUrl`
  - `gatewayApiKey`
  - `gatewayApiKeyEnv`
  - `systemPrompt`
- Added key resolution helpers (`firstNonEmpty`, env lookup)
- Added `callChatCompletions()` helper
- AI routing logic:
  - default: gateway-first (`http://127.0.0.1:18789/v1/chat/completions`)
  - fallback: external API (`aiBaseUrl`) if configured
- Config merge priority:
  1. `plugins.entries.notion-doc-comment.config`
  2. local `config.json` (legacy)
- Removed runtime debug noise logs

### 2) `openclaw.plugin.json`

- Bumped version to `0.2.0`
- Expanded `configSchema` to include new fields
- Added `uiHints.sensitive` for secret fields

### 3) `config.example.json`

- switched to env-first example
- added gateway-first defaults

### 4) `README.md`

- fixed clone URL
- documented env-first configuration
- documented gateway-first + fallback behavior
- documented `plugins.entries.<id>.config` usage

## Backward compatibility

- Existing `config.json` remains supported
- Existing external API mode continues to work

## Notes

- This PR intentionally keeps the polling architecture and comment-thread logic unchanged.
